### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,9 @@ flutter_native_splash:
   # android_gravity can be one of the following Android Gravity (see
   # https://developer.android.com/reference/android/view/Gravity): bottom, center,
   # center_horizontal, center_vertical, clip_horizontal, clip_vertical, end, fill, fill_horizontal,
-  # fill_vertical, left, right, start, or top.
+  # fill_vertical, left, right, start, or top. android_gravity can be combined using the | operator to achieve multiple effects. 
+  # For example:
+  # `android_gravity: fill|clip_vertical` - This will fill the width while maintaining the image's vertical aspect ratio
   #android_gravity: center
   #
   # ios_content_mode can be one of the following iOS UIView.ContentMode (see


### PR DESCRIPTION
I've updated the readme to include an important detail that will be helpful for newer developers or those less familiar with android documentation related to how to do the specific thing of filling AND cropping your splash screen:

android_gravity can be combined using the | operator to achieve multiple effects. For example: `android_gravity: fill|clip_vertical` - This will fill the width while maintaining the image's vertical aspect ratio

This is one of the most basic and important things you need to get the splash working well on an Android tablet like an Amazon Fire.